### PR TITLE
Add items with the expansion

### DIFF
--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -211,9 +211,10 @@ export interface IAbstractGraph extends EventEmitter {
    * @param {string} type 元素类型(node | edge)
    * @param {ModelConfig} model 元素数据模型
    * @param {boolean} stack 本次操作是否入栈，默认为 true
+   * @param {boolean} sortCombo 本次操作是否需要更新 combo 层级顺序，内部参数，用户在外部使用 addItem 时始终时需要更新
    * @return {Item} 元素实例
    */
-  addItem: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
+  addItem: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean, sortCombo?: boolean) => Item;
 
   /**
    * Performs an expansion with the passed items

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -219,7 +219,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * Performs an expansion with the passed items
    */
-  expand: () => void;
+  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean) => void;
 
   add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
 


### PR DESCRIPTION
This implements adding nodes to the graph via the `.expansion` function. This PR takes care of adding the operation to the undo stack (for future use)

This PR contains the fix for the undo-redo functionality committed here https://github.com/antvis/G6/pull/3473 just to make it easier to test. Will be removed before opening the PR on antvis.

How to test:
- Download this demo app -> [demoreactapp-main.zip](https://github.com/sirensolutions/G6/files/7926327/demoreactapp-main.zip)
- run `npm install`
- Check out this branch, go into the packages/core folder and run `npm link`
- go to the demo app folder and run `npm link @antv/g6-core`
- now start the demo app with npm start

You'll end up with a single node on the screen. Pressing the `E` key will cause the expansion (some nodes should pop up on the top left corner). Now, pressing the `U` key will produce a console log showing the undo/redo stacks. You should see the expansion operation in the stack

https://user-images.githubusercontent.com/2861371/150806975-d8b4d054-9a8b-48c5-9ebb-56fa8ec3936d.mp4


