### PR TITLE
[INVE-17817] Move nodes await to make room for the expansion

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2377,11 +2377,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 根据 graph 上的 animateCfg 进行视图中节点位置动画接口
    */
-  public positionsAnimate(): void {
+  public positionsAnimate(animateConfig?: GraphAnimateConfig): void {
     const self = this;
     self.emit('beforeanimate');
 
-    const animateCfg: GraphAnimateConfig = self.get('animateCfg');
+    const animateCfg: GraphAnimateConfig = animateConfig || self.get('animateCfg');
 
     const { onFrame } = animateCfg;
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1244,6 +1244,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     items: { type: ITEM_TYPE, model: ModelConfig }[] = [],
     stack: boolean = true,
     sortCombo: boolean = true,
+    animate?: boolean,
     animateCfg?: GraphAnimateConfig
   ) {
     const currentComboSorted = this.get('comboSorted');
@@ -1367,7 +1368,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       let moved = false;
       // compute distance with previously processed nodes
       for (var p = 0; p < prevOrigins.length; p++) {
-        const procEntry = prevOrigins[p]
+        const procEntry = prevOrigins[p];
         const procModel = procEntry.model;
         const minDistance = entry.maxRadius + procEntry.maxRadius + levelOffset / 2;
 
@@ -1479,7 +1480,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       });
     }
 
-    this.positionsAnimate(animateCfg);
+    if (animate) {
+      this.positionsAnimate(animateCfg);
+    } else {
+      this.refreshPositions();
+    }
 
     return returnItems;
   }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1243,7 +1243,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   public expand(
     items: { type: ITEM_TYPE, model: ModelConfig }[] = [],
     stack: boolean = true,
-    sortCombo: boolean = true
+    sortCombo: boolean = true,
+    animateCfg?: GraphAnimateConfig
   ) {
     const currentComboSorted = this.get('comboSorted');
     this.set('comboSorted', currentComboSorted && !sortCombo);
@@ -1350,7 +1351,60 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     }
 
     //
-    // 5. Compute the circular layout
+    // 5. Spread the origin nodes, to make room for the expansion
+    //
+
+    function getPositionAlongTheLine(x1: number, y1: number, x2: number, y2: number, factor: number) {
+      if (x1 === x2 && y1 === y2) {
+        x1 = x1 + 1;
+        y1 = y1 + 1;
+      }
+      return { x: x1 * (1.0 - factor) + x2 * factor, y: y1 * (1.0 - factor) + y2 * factor };
+    }
+    // Move the entry away from all the previously processed origins
+    function movedEntryIfNeeded(entry, prevOrigins) {
+      const sourceModel = entry.model;
+      let moved = false;
+      // compute distance with previously processed nodes
+      for (var p = 0; p < prevOrigins.length; p++) {
+        const procEntry = prevOrigins[p]
+        const procModel = procEntry.model;
+        const minDistance = entry.maxRadius + procEntry.maxRadius + levelOffset / 2;
+
+        //If the x/y are the same offset them a little to avoid infinite loops
+        sourceModel.x = sourceModel.x === procModel.x ? sourceModel.x + 10 : sourceModel.x;
+        sourceModel.y = sourceModel.y === procModel.y ? sourceModel.y + 10 : sourceModel.y;
+        const a = sourceModel.x - procModel.x;
+        const b = sourceModel.y - procModel.y;
+
+        let distance = Math.abs(Math.sqrt(a * a + b * b));
+        distance = distance < 1 ? 1 : distance;
+        if (distance < minDistance) {
+          // Move node along the line (this makes the node move away from the processedNode)
+          const factor = (minDistance / distance) + 0.01;
+          const position = getPositionAlongTheLine(procModel.x, procModel.y, sourceModel.x, sourceModel.y, factor);
+          sourceModel.x = position.x;
+          sourceModel.y = position.y;
+          moved = true;
+        }
+      }
+      return moved;
+    }
+
+    var processedOrigins = [];
+    for (let i = 0; i < originModelsEntries.length; i++) {
+      const entry = originModelsEntries[i][1];
+      const moved = movedEntryIfNeeded(entry, processedOrigins);
+      if (moved) {
+        // If it was moved reprocess it to ensure distances are ok
+        i--;
+      } else {
+        processedOrigins.push(entry);
+      }
+    }
+
+    //
+    // 6. Compute the circular layout
     //
     // This is used to move the nodes along the radius to break the perfect circles
     var offsetRandom = [2, -5, 5, -8, 9, -3]; // random numbers between [-10,10]
@@ -1367,7 +1421,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         const remainingNodes = nodes.length - prevNodesStartingIndex;
         nodesPerLevel = remainingNodes < nodesPerLevel ? remainingNodes : nodesPerLevel;
 
-        const angle = 2 * Math.PI / nodesPerLevel;
+        const baseAngle = 2 * Math.PI / nodesPerLevel;
         const levelRadius = radius + levelOffset * l;
         for (let m = 0; m < nodesPerLevel; m++) {
           const item = nodes[prevNodesStartingIndex + m];
@@ -1380,8 +1434,10 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           const originModel = originsMap[targetsMap[item.getID()].originId].model;
 
           if (model.x && model.y) {
-            model.x = originModel.x + randomRadius * Math.sin(angle * m);
-            model.y = originModel.y + randomRadius * Math.cos(angle * m);
+            // (base angle * node number) + layer based offset
+            const angle = (baseAngle * m) + (l / 40);
+            model.x = originModel.x + randomRadius * Math.sin(angle);
+            model.y = originModel.y + randomRadius * Math.cos(angle);
           }
 
           offsetRandomIndex = offsetRandomIndex === offsetRandom.length - 1 ? 0 : offsetRandomIndex + 1;
@@ -1389,9 +1445,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         prevNodesStartingIndex = nodesPerLevel + prevNodesStartingIndex;
       }
     }
-
-    this.autoPaint();
-    this.positionsAnimate();
 
     if (stack && this.get('enabledStack')) {
       const after: GraphData = { nodes: [], edges: [], combos: [] };
@@ -1425,6 +1478,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         after,
       });
     }
+
+    this.positionsAnimate(animateCfg);
 
     return returnItems;
   }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1378,8 +1378,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         const a = sourceModel.x - procModel.x;
         const b = sourceModel.y - procModel.y;
 
-        let distance = Math.abs(Math.sqrt(a * a + b * b));
-        distance = distance < 1 ? 1 : distance;
+        const distance = Math.max(Math.abs(Math.sqrt(a * a + b * b)), 1)
         if (distance < minDistance) {
           // Move node along the line (this makes the node move away from the processedNode)
           const factor = (minDistance / distance) + 0.01;

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -219,7 +219,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * Performs an expansion with the passed items
    */
-  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean) => void;
+  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
 

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -286,7 +286,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * 根据 graph 上的 animateCfg 进行视图中节点位置动画接口
    */
-  positionsAnimate: () => void;
+  positionsAnimate: (animateCfg?: GraphAnimateConfig) => void;
 
   /**
    * 当节点位置在外部发生改变时，刷新所有节点位置，重计算边

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -219,7 +219,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * Performs an expansion with the passed items
    */
-  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean, animateCfg?: GraphAnimateConfig) => void;
+  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
 


### PR DESCRIPTION
With this PR the expansion function will automatically move the origin points away to make room for the expansion.
Additionally, this adds the possibility to customize the animation params for the `positionsAnimate` function

How to test:
- Download this demo app -> [demoreactapp-main.zip](https://github.com/sirensolutions/G6/files/7926327/demoreactapp-main.zip)
- run `npm install`
- Check out this branch, go into the packages/core folder and run `npm link`
- go to the demo app folder and run `npm link @antv/g6-core`
- now start the demo app with npm start

You'll end up with a single node on the screen. Pressing the `E` key will cause the expansion (some nodes should pop up on the top left corner). Now, pressing the `U` key will produce a console log showing the undo/redo stacks. You should see the expansion operation in the stack

Notes:
- You can change the number of initial nodes in thee `App.js` file -> `const sourceCount = 3;`
- You can change the number of expanded nodes per node in the `expansion.tsx` file -> `const NODE_COUNT = 30;`

https://user-images.githubusercontent.com/2861371/151809884-de2dd952-1243-4789-888e-b72c3175d8e8.mp4


