### PR TITLE
[INVE-17843] Consider origin node size when expanding

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1242,8 +1242,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    */
   public expand(
     items: { type: ITEM_TYPE, model: ModelConfig }[] = [],
-    stack: boolean = true,
-    sortCombo: boolean = true,
+    {
+      stack = true,
+      sortCombo = true
+    }: {
+      stack?: boolean;
+      sortCombo?: boolean
+    },
     animate?: boolean,
     animateCfg?: GraphAnimateConfig
   ) {

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -219,7 +219,7 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * Performs an expansion with the passed items
    */
-  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], stack?: boolean, sortCombo?: boolean, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
+  expand: (items: { type: ITEM_TYPE, model: ModelConfig }[], opts?: { stack?: boolean; sortCombo?: boolean }, animate?: boolean, animateCfg?: GraphAnimateConfig) => void;
 
   add: (type: ITEM_TYPE, model: ModelConfig, stack?: boolean) => Item;
 


### PR DESCRIPTION
With this PR the expansion function will consider the origin node size to compute the minimum distance for the first layer of expanded nodes

How to test:
- Download this demo app -> [demoreactapp-main.zip](https://github.com/sirensolutions/G6/files/8002494/demoreactapp-main.zip)
- Run `npm install`
- Check out this branch, go into the packages/core folder and run `npm link`
- Go to the demo app folder and run `npm link @antv/g6-core`
- Start the demo app with `npm start`
- Press E to expand

Notes:
- You can change the number of initial nodes in thee `App.js` file -> `const sourceCount = 3;`
- You can change the number of expanded nodes per node in the `expansion.tsx` file -> `const NODE_COUNT = 30;`
- **Around line 45 of `App.js` you can pick the type of node for the origin nodes**