### PR TITLE
feat: Combo drag event is now a single action passed to the stack, allowing for undo/redo

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-core",
-  "version": "0.6.4-siren.1",
+  "version": "0.6.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-element",
-  "version": "0.6.4-siren.1",
+  "version": "0.6.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@antv/g-base": "^0.5.1",
-    "@antv/g6-core": "0.6.4-siren.1",
+    "@antv/g6-core": "0.6.4-siren.3",
     "@antv/util": "~2.0.5"
   },
   "devDependencies": {
@@ -87,6 +87,6 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^7.0.3",
     "typescript": "^3.9.5",
-    "@antv/g6": "4.6.4-siren.1"
+    "@antv/g6": "4.6.4-siren.3"
   }
 }

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "4.6.4-siren.1",
+  "version": "4.6.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -66,7 +66,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-pc": "0.6.4-siren.1"
+    "@antv/g6-pc": "0.6.4-siren.3"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/pc/package.json
+++ b/packages/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-pc",
-  "version": "0.6.4-siren.1",
+  "version": "0.6.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -75,9 +75,9 @@
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-math": "^0.1.1",
     "@antv/g-svg": "^0.5.1",
-    "@antv/g6-core": "0.6.4-siren.1",
-    "@antv/g6-element": "0.6.4-siren.1",
-    "@antv/g6-plugin": "0.6.4-siren.1",
+    "@antv/g6-core": "0.6.4-siren.3",
+    "@antv/g6-element": "0.6.4-siren.3",
+    "@antv/g6-plugin": "0.6.4-siren.3",
     "@antv/hierarchy": "^0.6.7",
     "@antv/layout": "^0.2.1",
     "@antv/matrix-util": "^3.1.0-beta.3",

--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -131,6 +131,9 @@ export default {
     // 获取所有选中的 Combo
     const combos = graph.findAllByState('combo', this.selectedState);
 
+    // exit if no combos selected
+    if (!combos.length) return;
+
     const currentCombo = item.get('id');
 
     const dragCombos = combos.filter((combo) => {

--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -215,7 +215,7 @@ export default {
         }
         // 将 Combo 放置到某个 Combo 上面时，只有当 onlyChangeComboSize 为 false 时候才更新 Combo 结构
         if (!this.onlyChangeComboSize) {
-          graph.updateComboTree(combo, targetModel.id);
+          graph.updateComboTree(combo, targetModel.id, false);
         } else {
           graph.updateCombo(combo);
         }
@@ -252,7 +252,7 @@ export default {
         if (!this.onlyChangeComboSize) {
           if (comboId !== combo.getID()) {
             droppedCombo = graph.findById(comboId);
-            if (comboId !== combo.getModel().parentId) graph.updateComboTree(combo, comboId);
+            if (comboId !== combo.getModel().parentId) graph.updateComboTree(combo, comboId, false);
           }
         } else {
           graph.updateCombo(combo);
@@ -264,7 +264,7 @@ export default {
         if (!this.onlyChangeComboSize) {
           const model = combo.getModel();
           if (model.comboId) {
-            graph.updateComboTree(combo);
+            graph.updateComboTree(combo, null, false);
           }
         } else {
           graph.updateCombo(combo);
@@ -335,7 +335,7 @@ export default {
       this.targets.map((combo: ICombo) => {
         // 将 Combo 放置到某个 Combo 上面时，只有当 onlyChangeComboSize 为 false 时候才更新 Combo 结构
         if (!this.onlyChangeComboSize) {
-          graph.updateComboTree(combo);
+          graph.updateComboTree(combo, null, false);
         } else {
           graph.updateCombo(combo);
         }
@@ -407,8 +407,7 @@ export default {
       y += origin.y - evt.y;
     }
 
-    graph.updateItem(item, { x, y });
-
+    graph.updateItem(item, { x, y }, false);
     graph.refreshPositions();
   },
 

--- a/packages/pc/src/util/combo-util.ts
+++ b/packages/pc/src/util/combo-util.ts
@@ -1,0 +1,56 @@
+import { NodeConfig, ICombo, ComboConfig, INode } from "@antv/g6-core";
+import { concat } from 'lodash';
+
+interface NestedChildren {
+    nodes: NodeConfig[],
+    combos: ComboConfig[]
+}
+
+/**
+ * Recursive function that returns modelConfig 
+ * array of combos and it's nested children (combos | nodes)
+ * @param {ICombo} combos 
+ * @returns {NestedChildren}
+ */
+export const returnNestedChildrenModels = (combos: ICombo[], nestedChildren?: NestedChildren): NestedChildren => {
+    let childNodes: NodeConfig[] = nestedChildren ? [...nestedChildren.nodes] : [];
+    let childCombos: ComboConfig[] = nestedChildren ? [...nestedChildren.combos] : [];
+    let children: { nodes: INode[]; combos: ICombo[] } = null;
+
+    if (!combos.length) {
+        return;
+    }
+
+    // Iterate through given combos
+    // & push nodes/combo to arrays
+    combos.map(combo => {
+        children = combo.getChildren();
+        children.nodes.map(node => {
+            childNodes.push(node.getModel() as NodeConfig);
+        })
+        childCombos.push(combo.getModel() as NodeConfig);
+    })
+
+    // Iterate through child combos or return arrays
+    if (children.combos.length !== 0) {
+        return children.combos
+            .map(combo =>
+                returnNestedChildrenModels(
+                    [combo],
+                    { nodes: childNodes, combos: childCombos }
+                )
+            )
+            .reduce((prev, next) => {
+                // combine nodes/combos of adjacent child combos
+                return {
+                    nodes: Array.from(new Set(concat(prev.nodes, next.nodes))),
+                    combos: Array.from(new Set(concat(prev.combos, next.combos)))
+                }
+            })
+    }
+
+    return {
+        nodes: childNodes,
+        combos: childCombos
+    }
+}

--- a/packages/pc/src/util/combo-util.ts
+++ b/packages/pc/src/util/combo-util.ts
@@ -1,5 +1,4 @@
 import { NodeConfig, ICombo, ComboConfig, INode } from "@antv/g6-core";
-import { concat } from 'lodash';
 
 interface NestedChildren {
     nodes: NodeConfig[],
@@ -43,8 +42,8 @@ export const returnNestedChildrenModels = (combos: ICombo[], nestedChildren?: Ne
             .reduce((prev, next) => {
                 // combine nodes/combos of adjacent child combos
                 return {
-                    nodes: Array.from(new Set(concat(prev.nodes, next.nodes))),
-                    combos: Array.from(new Set(concat(prev.combos, next.combos)))
+                    nodes: Array.from(new Set([...prev.nodes, ...next.nodes])),
+                    combos: Array.from(new Set([...prev.combos, ...next.combos]))
                 }
             })
     }

--- a/packages/pc/src/util/index.ts
+++ b/packages/pc/src/util/index.ts
@@ -1,8 +1,9 @@
 import * as ColorUtil from './color';
 import * as LayoutUtil from './layout';
 import * as GpuUtil from './gpu';
+import * as ComboUtil from './combo-util';
 import { Util } from '@antv/g6-core';
 
-const G6Util = { ...Util, ...ColorUtil, ...LayoutUtil, ...GpuUtil } as any;
+const G6Util = { ...Util, ...ColorUtil, ...LayoutUtil, ...GpuUtil, ...ComboUtil } as any;
 
 export default G6Util;

--- a/packages/pc/tests/unit/util/combo-util-spec.ts
+++ b/packages/pc/tests/unit/util/combo-util-spec.ts
@@ -1,6 +1,5 @@
 import G6, { ICombo } from '../../../src';
 import { returnNestedChildrenModels } from '../../../src/util/combo-util';
-import 'jest-canvas-mock'
 
 const div = document.createElement('div');
 div.id = 'container';

--- a/packages/pc/tests/unit/util/combo-util-spec.ts
+++ b/packages/pc/tests/unit/util/combo-util-spec.ts
@@ -1,0 +1,191 @@
+import G6, { ICombo } from '../../../src';
+import { returnNestedChildrenModels } from '../../../src/util/combo-util';
+import 'jest-canvas-mock'
+
+const div = document.createElement('div');
+div.id = 'container';
+document.body.appendChild(div);
+
+
+describe('Return all modelConfigs for children of combo, including combo model', () => {
+    it('should return selected combo and all nodes (no combo child)', () => {
+        const data = {
+            nodes: [
+                {
+                    id: "node1"
+                },
+                {
+                    id: "node2"
+                }
+            ]
+        };
+
+        const graph = new G6.Graph({
+            container: 'container'
+        });
+
+        graph.data(data);
+        graph.render();
+
+        //create combo
+        graph.createCombo('combo1', ['node1', 'node2'])
+
+        const item = graph.findById('combo1');
+        graph.setItemState(item, 'selected', true);
+
+        const combos = graph.findAllByState('combo', 'selected') as ICombo[];
+        const children = returnNestedChildrenModels(combos);
+
+
+        expect(children.nodes).toHaveLength(2);
+        expect(children.combos).toHaveLength(1);
+        expect(children.nodes.map(node => node.id)).toStrictEqual(["node1", "node2"])
+        expect(children.combos.map(combo => combo.id)).toStrictEqual(["combo1"])
+    })
+
+    it('should return selected combo and all nodes/combos within, nested 1 level', () => {
+        const data = {
+            nodes: [
+                {
+                    id: "node1"
+                },
+                {
+                    id: "node2"
+                },
+                {
+                    id: "node3"
+                },
+                {
+                    id: "node4"
+                },
+                {
+                    id: "node5"
+                }
+            ]
+        };
+
+        const graph = new G6.Graph({
+            container: 'container'
+        });
+
+        graph.data(data);
+        graph.render();
+
+        //create combo
+        graph.createCombo('combo1', ['node1', 'node3'])
+        graph.createCombo('combo2', ['node5'])
+        graph.createCombo('combo3', ['node2', 'node4', 'combo2'])
+
+        const item = graph.findById('combo3');
+        graph.setItemState(item, 'selected', true);
+
+        const combos = graph.findAllByState('combo', 'selected') as ICombo[];
+        const children = returnNestedChildrenModels(combos);
+
+
+        expect(children.nodes).toHaveLength(3);
+        expect(children.combos).toHaveLength(2);
+        expect(children.nodes.map(node => node.id)).toStrictEqual(["node2", "node4", "node5"])
+        expect(children.combos.map(combo => combo.id)).toStrictEqual(["combo3", "combo2"])
+    })
+
+    it('Should return multiple selected combos and all nodes/combos within, nested 2 levels', () => {
+        const data = {
+            nodes: [
+                {
+                    id: "node1"
+                },
+                {
+                    id: "node2"
+                },
+                {
+                    id: "node3"
+                },
+                {
+                    id: "node4"
+                },
+                {
+                    id: "node5"
+                },
+                {
+                    id: "node6"
+                },
+                {
+                    id: "node7"
+                },
+                {
+                    id: "node8"
+                }
+            ]
+        };
+
+        const graph = new G6.Graph({
+            container: 'container'
+        });
+
+        graph.data(data);
+        graph.render();
+
+        //create combo
+        // third level
+        graph.createCombo('childOfchildOfSelected', ['node8'])
+
+        // second level
+        graph.createCombo('childOfSelected', ['node5', 'childOfchildOfSelected'])
+
+        // top level
+        graph.createCombo('select1', ['node1', 'node3'])
+        graph.createCombo('select2', ['node2', 'node4', 'childOfSelected'])
+        graph.createCombo('unselected1', ['node7', 'node6'])
+
+        const item = graph.findById('select1');
+        const item2 = graph.findById('select2');
+        graph.setItemState(item, 'selected', true);
+        graph.setItemState(item2, 'selected', true);
+
+        const combos = graph.findAllByState('combo', 'selected') as ICombo[];
+        const children = returnNestedChildrenModels(combos);
+
+        expect(children.nodes).toHaveLength(6);
+        expect(children.combos).toHaveLength(4);
+        expect(children.nodes.map(node => node.id)).toStrictEqual(['node1', 'node3', 'node2', 'node4', 'node5', 'node8'])
+        expect(children.combos.map(combo => combo.id)).toStrictEqual(['select1', 'select2', 'childOfSelected', 'childOfchildOfSelected'])
+    })
+
+    it('Should return selected combo and all adjacent nested combos, and its nodes', () => {
+        const data = {
+            nodes: [
+                {
+                    id: "node1"
+                },
+                {
+                    id: "node2"
+                }
+            ]
+        };
+
+        const graph = new G6.Graph({
+            container: 'container'
+        });
+
+        graph.data(data);
+        graph.render();
+
+        //create combo
+        graph.createCombo('childCombo2', ['node2'])
+        graph.createCombo('childCombo1', ['node1'])
+
+        graph.createCombo('parentGroup', ['childCombo1', 'childCombo2'])
+
+        const item = graph.findById('parentGroup');
+        graph.setItemState(item, 'selected', true);
+
+        const combos = graph.findAllByState('combo', 'selected') as ICombo[];
+        const children = returnNestedChildrenModels(combos);
+
+        expect(children.nodes).toHaveLength(2);
+        expect(children.combos).toHaveLength(3);
+        expect(children.nodes.map(node => node.id)).toEqual(['node1', 'node2'])
+        expect(children.combos.map(combo => combo.id)).toEqual(['parentGroup', 'childCombo1', 'childCombo2'])
+    })
+})

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-plugin",
-  "version": "0.6.4-siren.1",
+  "version": "0.6.4-siren.3",
   "description": "G6 Plugin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -22,7 +22,7 @@
     "@antv/g-base": "^0.5.1",
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-svg": "^0.5.2",
-    "@antv/g6-core": "0.6.4-siren.1",
+    "@antv/g6-core": "0.6.4-siren.3",
     "@antv/matrix-util": "^3.1.0-beta.3",
     "@antv/scale": "^0.3.4",
     "@antv/util": "^2.0.9",
@@ -57,6 +57,6 @@
     "jquery": "^3.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "@antv/g6": "4.6.4-siren.1"
+    "@antv/g6": "4.6.4-siren.3"
   }
 }

--- a/packages/react-node/package.json
+++ b/packages/react-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/g6-react-node",
   "description": "Using React Component to Define Your G6 Graph Node",
-  "version": "1.3.0-siren.1",
+  "version": "1.3.0-siren.3",
   "scripts": {
     "start": "dumi dev",
     "build": "father-build",
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-core": "0.6.4-siren.1",
+    "@antv/g6-core": "0.6.4-siren.3",
     "@antv/g-base": "^0.5.1",
     "@types/yoga-layout": "^1.9.3",
     "react": "^16.12.0",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@antv/g6-site",
-  "version": "4.6.4-siren.1",
+  "version": "4.6.4-siren.3",
   "description": "G6 sites deployed on gh-pages",
   "keywords": [
     "antv",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@antv/chart-node-g6": "^0.0.3",
-    "@antv/g6": "4.6.4-siren.1",
+    "@antv/g6": "4.6.4-siren.3",
     "@antv/gatsby-theme-antv": "1.1.15",
     "@antv/util": "^2.0.9",
     "@antv/vis-predict-engine": "^0.1.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

* Combo drag event will no longer spam the stack with `update` actions.
* Added combo utility to return configModels of both the nested nodes and combos.
* Combo drag event  is now a single action passed to the stack, allowing for undo/redo