### PR TITLE
fix: Invoking uncombo() on collapsed combos will no longer delete children

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-core",
-  "version": "0.6.4-siren.3",
+  "version": "0.6.4-siren.4",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1800,6 +1800,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       return;
     }
 
+    // Expand combo if collapsed to prevent child nodes being deleted.
+    if (comboItem.getModel().collapsed) {
+      this.expandCombo(comboItem);
+    }
+
     const parentId = comboItem.getModel().parentId;
     let comboTrees = self.get('comboTrees');
     if (!comboTrees) comboTrees = [];

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-element",
-  "version": "0.6.4-siren.3",
+  "version": "0.6.4-siren.4",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@antv/g-base": "^0.5.1",
-    "@antv/g6-core": "0.6.4-siren.3",
+    "@antv/g6-core": "0.6.4-siren.4",
     "@antv/util": "~2.0.5"
   },
   "devDependencies": {
@@ -87,6 +87,6 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^7.0.3",
     "typescript": "^3.9.5",
-    "@antv/g6": "4.6.4-siren.3"
+    "@antv/g6": "4.6.4-siren.4"
   }
 }

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "4.6.4-siren.3",
+  "version": "4.6.4-siren.4",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -66,7 +66,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-pc": "0.6.4-siren.3"
+    "@antv/g6-pc": "0.6.4-siren.4"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/pc/package.json
+++ b/packages/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-pc",
-  "version": "0.6.4-siren.3",
+  "version": "0.6.4-siren.4",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -75,9 +75,9 @@
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-math": "^0.1.1",
     "@antv/g-svg": "^0.5.1",
-    "@antv/g6-core": "0.6.4-siren.3",
-    "@antv/g6-element": "0.6.4-siren.3",
-    "@antv/g6-plugin": "0.6.4-siren.3",
+    "@antv/g6-core": "0.6.4-siren.4",
+    "@antv/g6-element": "0.6.4-siren.4",
+    "@antv/g6-plugin": "0.6.4-siren.4",
     "@antv/hierarchy": "^0.6.7",
     "@antv/layout": "^0.2.1",
     "@antv/matrix-util": "^3.1.0-beta.3",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-plugin",
-  "version": "0.6.4-siren.3",
+  "version": "0.6.4-siren.4",
   "description": "G6 Plugin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -22,7 +22,7 @@
     "@antv/g-base": "^0.5.1",
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-svg": "^0.5.2",
-    "@antv/g6-core": "0.6.4-siren.3",
+    "@antv/g6-core": "0.6.4-siren.4",
     "@antv/matrix-util": "^3.1.0-beta.3",
     "@antv/scale": "^0.3.4",
     "@antv/util": "^2.0.9",
@@ -57,6 +57,6 @@
     "jquery": "^3.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "@antv/g6": "4.6.4-siren.3"
+    "@antv/g6": "4.6.4-siren.4"
   }
 }

--- a/packages/react-node/package.json
+++ b/packages/react-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/g6-react-node",
   "description": "Using React Component to Define Your G6 Graph Node",
-  "version": "1.3.0-siren.3",
+  "version": "1.3.0-siren.4",
   "scripts": {
     "start": "dumi dev",
     "build": "father-build",
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-core": "0.6.4-siren.3",
+    "@antv/g6-core": "0.6.4-siren.4",
     "@antv/g-base": "^0.5.1",
     "@types/yoga-layout": "^1.9.3",
     "react": "^16.12.0",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@antv/g6-site",
-  "version": "4.6.4-siren.3",
+  "version": "4.6.4-siren.4",
   "description": "G6 sites deployed on gh-pages",
   "keywords": [
     "antv",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@antv/chart-node-g6": "^0.0.3",
-    "@antv/g6": "4.6.4-siren.3",
+    "@antv/g6": "4.6.4-siren.4",
     "@antv/gatsby-theme-antv": "1.1.15",
     "@antv/util": "^2.0.9",
     "@antv/vis-predict-engine": "^0.1.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

Fixed issue where children of collapsed combo would be deleted when invoking uncombo.



https://user-images.githubusercontent.com/7975925/175073956-97cd466c-44bc-4bd3-9a13-62b88756ce71.mp4


https://user-images.githubusercontent.com/7975925/175073949-3b3094d9-8146-4788-a4a8-95bf6f44f8e5.mp4

