### PR TITLE
[INVE-17480] fix: perform zoom after translate

### DIFF
--- a/packages/core/src/graph/controller/view.ts
+++ b/packages/core/src/graph/controller/view.ts
@@ -1,11 +1,11 @@
 import { AbstractCanvas } from '@antv/g-base';
 import { Point, IGroup } from '@antv/g-base';
 import { isNumber, isString } from '@antv/util';
-import { modifyCSS } from '@antv/dom-util';
 import { Item, Matrix, Padding, GraphAnimateConfig, IEdge, FitViewRules } from '../../types';
 import { formatPadding } from '../../util/base';
 import { applyMatrix, invertMatrix } from '../../util/math';
 import { IAbstractGraph } from '../../interface/graph';
+import { getAnimateCfgWithCallback } from '../../util/graphic';
 
 export default class ViewController {
   private graph: IAbstractGraph;
@@ -62,15 +62,28 @@ export default class ViewController {
       y: bbox.y + bbox.height / 2,
     };
 
-    graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateCfg);
-    const w = (width - padding[1] - padding[3]) / bbox.width;
-    const h = (height - padding[0] - padding[2]) / bbox.height;
-    let ratio = w;
-    if (w > h) {
-      ratio = h;
+    function doZoom() {
+      const w = (width - padding[1] - padding[3]) / bbox.width;
+      const h = (height - padding[0] - padding[2]) / bbox.height;
+      let ratio = w;
+      if (w > h) {
+        ratio = h;
+      }
+
+      if (!graph.zoom(ratio, viewCenter, animate, animateCfg)) {
+        console.warn('zoom failed, ratio out of range, ratio: %f', ratio);
+      }
     }
-    if (!graph.zoom(ratio, viewCenter)) {
-      console.warn('zoom failed, ratio out of range, ratio: %f', ratio);
+
+    if (animate) {
+      const animateConfig = getAnimateCfgWithCallback({
+        animateCfg,
+        callback: () => { doZoom(); }
+      });
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateConfig);
+    } else {
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
+      doZoom();
     }
   }
 
@@ -97,32 +110,44 @@ export default class ViewController {
       y: bbox.y + bbox.height / 2,
     };
 
-    graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateCfg);
-    const wRatio = (width - padding[1] - padding[3]) / bbox.width;
-    const hRatio = (height - padding[0] - padding[2]) / bbox.height;
-    let ratio;
-    if (direction === 'x') {
-      ratio = wRatio;
-    } else if (direction === 'y') {
-      ratio = hRatio;
-    } else {
-      // ratioRule
-      ratio = ratioRule === 'max' ? Math.max(wRatio, hRatio) : Math.min(wRatio, hRatio);
-    }
-    // 如果设置了仅对超出视口宽高的场景进行fitview，则没超出的场景zoom取1
-    if (onlyOutOfViewPort) {
-      ratio = ratio < 1 ? ratio : 1;
+    function doZoom() {
+      const wRatio = (width - padding[1] - padding[3]) / bbox.width;
+      const hRatio = (height - padding[0] - padding[2]) / bbox.height;
+      let ratio;
+      if (direction === 'x') {
+        ratio = wRatio;
+      } else if (direction === 'y') {
+        ratio = hRatio;
+      } else {
+        // ratioRule
+        ratio = ratioRule === 'max' ? Math.max(wRatio, hRatio) : Math.min(wRatio, hRatio);
+      }
+      // 如果设置了仅对超出视口宽高的场景进行fitview，则没超出的场景zoom取1
+      if (onlyOutOfViewPort) {
+        ratio = ratio < 1 ? ratio : 1;
+      }
+
+      const initZoomRatio = graph.getZoom();
+      let endZoom = initZoomRatio * ratio;
+      const minZoom = graph.get('minZoom');
+      // 如果zoom小于最小zoom, 则以最小zoom为准
+      if (endZoom < minZoom) {
+        endZoom = minZoom;
+        console.warn('fitview failed, ratio out of range, ratio: %f', ratio, 'graph minzoom has been used instead');
+      }
+      graph.zoomTo(endZoom, viewCenter, animate, animateCfg);
     }
 
-    const initZoomRatio = graph.getZoom();
-    let endZoom = initZoomRatio * ratio;
-    const minZoom = graph.get('minZoom');
-    // 如果zoom小于最小zoom, 则以最小zoom为准
-    if (endZoom < minZoom) {
-      endZoom = minZoom;
-      console.warn('fitview failed, ratio out of range, ratio: %f', ratio, 'graph minzoom has been used instead');
+    if (animate) {
+      const animateConfig = getAnimateCfgWithCallback({
+        animateCfg,
+        callback: () => { doZoom(); }
+      });
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateConfig);
+    } else {
+      graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
+      doZoom();
     }
-    graph.zoomTo(endZoom, viewCenter, animate, animateCfg);
   }
 
   public getFormatPadding(): number[] {

--- a/packages/core/src/graph/controller/view.ts
+++ b/packages/core/src/graph/controller/view.ts
@@ -62,7 +62,7 @@ export default class ViewController {
       y: bbox.y + bbox.height / 2,
     };
 
-    function doZoom() {
+    function doZoom(viewCenter, animate, animateCfg) {
       const w = (width - padding[1] - padding[3]) / bbox.width;
       const h = (height - padding[0] - padding[2]) / bbox.height;
       let ratio = w;
@@ -78,12 +78,14 @@ export default class ViewController {
     if (animate) {
       const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
-        callback: () => { doZoom(); }
+        callback: () => {
+          doZoom(viewCenter, animate, animateCfg);
+        }
       });
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateConfig);
     } else {
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
-      doZoom();
+      doZoom(viewCenter, animate, animateCfg);
     }
   }
 
@@ -110,7 +112,7 @@ export default class ViewController {
       y: bbox.y + bbox.height / 2,
     };
 
-    function doZoom() {
+    function doZoom(bbox, padding, onlyOutOfViewPort, graph, animate, animateCfg) {
       const wRatio = (width - padding[1] - padding[3]) / bbox.width;
       const hRatio = (height - padding[0] - padding[2]) / bbox.height;
       let ratio;
@@ -141,12 +143,12 @@ export default class ViewController {
     if (animate) {
       const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
-        callback: () => { doZoom(); }
+        callback: () => { doZoom(bbox, padding, onlyOutOfViewPort, graph, animate, animateCfg); }
       });
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y, animate, animateConfig);
     } else {
       graph.translate(viewCenter.x - groupCenter.x, viewCenter.y - groupCenter.y);
-      doZoom();
+      doZoom(bbox, padding, onlyOutOfViewPort, graph, animate, animateCfg);
     }
   }
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -37,7 +37,7 @@ import { lerp, move } from '../util/math';
 import { dataValidation, singleDataValidation } from '../util/validation';
 import Global from '../global';
 import { ItemController, ModeController, StateController, ViewController } from './controller';
-import { plainCombosToTrees, traverseTree, reconstructTree, traverseTreeUp } from '../util/graphic';
+import { plainCombosToTrees, traverseTree, reconstructTree, traverseTreeUp, getAnimateCfgWithCallback } from '../util/graphic';
 import Hull from '../item/hull';
 
 const { transform } = ext;
@@ -557,34 +557,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     return this.findAll(type, item => item.hasState(state));
   }
 
-  private getAnimateCfgWithCallback({
-    animateCfg,
-    callback
-  }: {
-    animateCfg: GraphAnimateConfig;
-    callback: () => void;
-  }): GraphAnimateConfig {
-    let animateConfig: GraphAnimateConfig;
-    if (!animateCfg) {
-      animateConfig = {
-        duration: 500,
-        callback
-      };
-    } else {
-      animateConfig = clone(animateCfg);
-      if (animateCfg.callback) {
-        const animateCfgCallback = animateCfg.callback;
-        animateConfig.callback = () => {
-          callback();
-          animateCfgCallback();
-        }
-      } else {
-        animateConfig.callback = callback;
-      }
-    }
-    return animateConfig;
-  }
-
   /**
    * 平移画布
    * @param dx 水平方向位移
@@ -600,7 +572,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       matrix = [1, 0, 0, 0, 1, 0, 0, 0, 1];
     }
     if (animate) {
-      const animateConfig = this.getAnimateCfgWithCallback({
+      const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
         callback: () => this.emit('viewportchange', { action: 'translate', matrix: group.getMatrix() })
       });
@@ -760,7 +732,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       const initialRatio = aniMatrix[0];
       const targetRatio = initialRatio * ratio;
 
-      const animateConfig = this.getAnimateCfgWithCallback({
+      const animateConfig = getAnimateCfgWithCallback({
         animateCfg,
         callback: () => this.emit('viewportchange', { action: 'zoom', matrix: group.getMatrix() })
       });

--- a/packages/core/src/util/graphic.ts
+++ b/packages/core/src/util/graphic.ts
@@ -10,7 +10,8 @@ import {
   NodeConfig,
   ComboTree,
   ComboConfig,
-  ICombo
+  ICombo,
+  GraphAnimateConfig
 } from '../types';
 import { applyMatrix } from './math';
 import letterAspectRatio from './letterAspectRatio';
@@ -685,4 +686,32 @@ export const cloneBesidesImg = (obj) => {
     }
   });
   return clonedObj;
+}
+
+export const getAnimateCfgWithCallback = ({
+  animateCfg,
+  callback
+}: {
+  animateCfg: GraphAnimateConfig;
+  callback: () => void;
+}): GraphAnimateConfig => {
+  let animateConfig: GraphAnimateConfig;
+  if (!animateCfg) {
+    animateConfig = {
+      duration: 500,
+      callback
+    };
+  } else {
+    animateConfig = clone(animateCfg);
+    if (animateCfg.callback) {
+      const animateCfgCallback = animateCfg.callback;
+      animateConfig.callback = () => {
+        callback();
+        animateCfgCallback();
+      }
+    } else {
+      animateConfig.callback = callback;
+    }
+  }
+  return animateConfig;
 }

--- a/packages/core/tests/unit/graph/controller/view-spec.ts
+++ b/packages/core/tests/unit/graph/controller/view-spec.ts
@@ -113,8 +113,8 @@ describe('view', () => {
   });
   it('focus edge', () => {
     const data = {
-      nodes: [{id: '1', x: 10, y: 10}, {id: '2', x: 25, y: 40}, {id: '3', x: -50, y: 80}],
-      edges: [{source: '1', target: '2'}, {source: '1', target: '3'}]
+      nodes: [{ id: '1', x: 10, y: 10 }, { id: '2', x: 25, y: 40 }, { id: '3', x: -50, y: 80 }],
+      edges: [{ source: '1', target: '2' }, { source: '1', target: '3' }]
     }
     const g = new Graph({
       container: div,
@@ -122,7 +122,7 @@ describe('view', () => {
       height: 500,
     })
     g.read(data);
-    g.get('canvas').get('el').style.backgroundColor='#ccc';
+    g.get('canvas').get('el').style.backgroundColor = '#ccc';
     g.zoom(2, { x: 10, y: 10 });
     g.focusItem(g.getEdges()[0]);
     let centerPoint = g.getPointByCanvas(250, 250);
@@ -185,6 +185,16 @@ describe('fitViewByRules, not out of viewport', () => {
     expect(bboxAfterFitView.width).toEqual(bbox.width);
     expect(bboxAfterFitView.height).toEqual(bbox.height);
   });
+  it('fitViewByRules, not out of viewport, custom rules, animated', async () => {
+    graph.fitView(0, { onlyOutOfViewPort: true }, true, { duration: 10 });
+    await new Promise((r) => setTimeout(r, 50));
+    const bboxAfterFitView = graph.get('canvas').getCanvasBBox();
+    expect(graph.getZoom()).toEqual(1);
+    expect(numberEqual(bboxAfterFitView.x, 100, 1)).toBe(true);
+    expect(numberEqual(bboxAfterFitView.y, 150, 1)).toBe(true);
+    expect(bboxAfterFitView.width).toEqual(bbox.width);
+    expect(bboxAfterFitView.height).toEqual(bbox.height);
+  });
 });
 
 describe('fitViewByRules, out of viewport', () => {
@@ -233,6 +243,16 @@ describe('fitViewByRules, out of viewport', () => {
   });
   it('fitViewByRules, out of viewport, custom rules', () => {
     graph.fitView(0, { onlyOutOfViewPort: true, direction: 'y' });
+    const bbox = graph.get('canvas').getCanvasBBox();
+    expect(numberEqual(graph.getZoom(), 0.28, 0.01)).toBe(true);
+    expect(numberEqual(bbox.x, -18, 1)).toBe(true);
+    expect(numberEqual(bbox.y, 10, 1)).toBe(true);
+    expect(numberEqual(bbox.width, 536, 1)).toBe(true);
+    expect(numberEqual(bbox.height, 480, 1)).toBe(true);
+  });
+  it('fitViewByRules, out of viewport, custom rules, animated', async () => {
+    graph.fitView(0, { onlyOutOfViewPort: true, direction: 'y' }, true, { duration: 10 });
+    await new Promise((r) => setTimeout(r, 50));
     const bbox = graph.get('canvas').getCanvasBBox();
     expect(numberEqual(graph.getZoom(), 0.28, 0.01)).toBe(true);
     expect(numberEqual(bbox.x, -18, 1)).toBe(true);


### PR DESCRIPTION
This ensures we're calling the zoom function only after the translate animation finishes