### PR TITLE
[INVE-19531] [G6] [Combos] If group is collapsed, the edge to group is replaced by regular line

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2687,14 +2687,12 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return;
         }
 
-        addedVEdgeMap[key] = {
-          ...originalEdgeModel,
-          ...vEdgeInfo
-        };
+        addedVEdgeMap[key] = vEdgeInfo;
 
-        if (addedVEdgeMap[key].style) {
+        if (originalEdgeModel.style) {
           // do not apply any status styles to vedge
           // as it should not be interacted
+          addedVEdgeMap[key].style = originalEdgeModel.style;
           addedVEdgeMap[key].style.status = {};
         }
       }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -42,6 +42,7 @@ import Hull from '../item/hull';
 
 const { transform } = ext;
 const NODE = 'node';
+const comboEdgeIdPrefix = 'combo-edge-';
 
 export interface PrivateGraphOption extends GraphOptions {
   data: GraphData;
@@ -2175,6 +2176,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     });
 
     each(this.get('edges'), (edge: IEdge) => {
+      const edgeId = edge.getID();
+      if (edgeId && edgeId.startsWith(comboEdgeIdPrefix)) {
+        return;
+      }
+
       edges.push(getModelWithStates(edge) as EdgeConfig);
     });
 
@@ -2685,8 +2691,14 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         addedVEdgeMap[key] = {
           ...originalEdgeModel,
           ...vEdgeInfo,
-          id: `virtual-edge-for-${originalEdgeModel.id}`
+          id: comboEdgeIdPrefix + originalEdgeModel.id
         };
+
+        if (originalEdgeModel.id) {
+          addedVEdgeMap[key].id = comboEdgeIdPrefix + originalEdgeModel.id;
+        } else {
+          addedVEdgeMap[key].id = comboEdgeIdPrefix + Math.random() + Date.now();
+        }
       }
     });
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2631,8 +2631,10 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     edges.forEach(edge => {
       const { isVEdge, size = 1 } = edge.getModel();
       if (edge.isVisible() && !isVEdge) return;
-      let source = edge.getSource();
-      let target = edge.getTarget();
+      const originalEdgeModel = edge.getModel();
+      const source = edge.getSource();
+      const target = edge.getTarget();
+
       let otherEnd = null;
       let otherEndIsSource;
       if (source.getModel().id === comboModel.id ||
@@ -2664,7 +2666,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
         const otherEndId = otherEndModel.id;
 
-        const vEdgeInfo = otherEndIsSource ? {
+        const vEdgeInfo: Record<string, unknown> = otherEndIsSource ? {
           source: otherEndId,
           target: comboModel.id,
           size,
@@ -2680,14 +2682,18 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           addedVEdgeMap[key].size += size;
           return;
         }
-        addedVEdgeMap[key] = vEdgeInfo;
+        addedVEdgeMap[key] = {
+          ...originalEdgeModel,
+          ...vEdgeInfo,
+          id: `virtual-edge-for-${originalEdgeModel.id}`
+        };
       }
     });
 
     // update the width of the virtual edges, which is the sum of merged actual edges
     // be attention that the actual edges with same endpoints but different directions will be represented by two different virtual edges
     this.addItems(
-      Object.values(addedVEdgeMap).map(edgeInfo => ({ type: 'vedge', model: edgeInfo as EdgeConfig })),
+      Object.values(addedVEdgeMap).map(edgeInfo => ({ type: 'edge', model: edgeInfo as EdgeConfig })),
       false
     );
     this.emit('aftercollapseexpandcombo', { action: 'collapse', item: combo });


### PR DESCRIPTION
The issue is 
`collapseCombo` and `expandCombo` methods are using special item type `vedge` which is not considered by most of interactions. `vedge` is created without any styling and only inherits default edge styles. This PR will only fix the styling issue - `vedge` will be created with styles inherited from original edge (which is used to build this `vedge`).

The question would be is why we need this special type `vedge`. I will open separate ticket about it to investigate as this abstraction is not needed as i see at the moment. 

BEFORE
![Peek 2022-09-30 16-27](https://user-images.githubusercontent.com/36245750/193304779-7fc40f25-62f7-4da0-9fe5-16e71c17acf0.gif)

AFTER
![Peek 2022-09-30 16-29](https://user-images.githubusercontent.com/36245750/193304804-6d7cb7b7-853a-4c76-aa05-a4a0de3f9762.gif)


