### PR TITLE
fix: onClick will no longer fire when double clicking a node

### DIFF
--- a/packages/pc/src/behavior/click-select.ts
+++ b/packages/pc/src/behavior/click-select.ts
@@ -1,4 +1,4 @@
-import { each } from '@antv/util';
+import { each, debounce } from '@antv/util';
 import { G6Event, IG6GraphEvent } from '@antv/g6-core';
 
 const DEFAULT_TRIGGER = 'shift';
@@ -27,14 +27,14 @@ export default {
     }
     if (!self.multiple) {
       return {
-        'node:click': 'onClick',
+        'node:click': 'debounceOnClick',
         'combo:click': 'onClick',
         'edge:click': 'onClick',
         'canvas:click': 'onCanvasClick',
       };
     }
     return {
-      'node:click': 'onClick',
+      'node:click': 'debounceOnClick',
       'combo:click': 'onClick',
       'edge:click': 'onClick',
       'canvas:click': 'onCanvasClick',
@@ -43,6 +43,11 @@ export default {
     };
   },
   onClick(evt: IG6GraphEvent) {
+    // Return if double click
+    if (evt.originalEvent.detail === 2) {
+      return
+    }
+
     const self = this;
     const { item } = evt;
     if (!item || item.destroyed) {
@@ -129,6 +134,12 @@ export default {
       });
     }
   },
+  debounceOnClick: debounce(
+    // Prevent onClick firing twice when double clicking
+    function (evt: IG6GraphEvent) {
+      this.onClick(evt);
+    }, 300
+  ),
   onCanvasClick(evt: IG6GraphEvent) {
     const { graph, shouldBegin } = this;
     if (!shouldBegin.call(this, evt)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

When double clicking a node the `onClick` event will fire twice before firing a `dblclick` event. This simply delays the `onClick` and checks the detail property (via the `originalevent` object) to see how many clicks were made.
