### PR TITLE
[INVE-19535] Fix comboTrees update in createCombo()

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-core",
-  "version": "0.7.4-siren.1",
+  "version": "0.7.4-siren.2",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -64,7 +64,7 @@ const colorSet = {
 };
 
 export default {
-  version: '0.7.4-siren.0',
+  version: '0.7.4-siren.2',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',

--- a/packages/core/src/graph/controller/item.ts
+++ b/packages/core/src/graph/controller/item.ts
@@ -171,7 +171,7 @@ export default class ItemController {
       item = new Combo({
         model,
         styles,
-        animate: false,
+        animate: graph.get('animate'),
         bbox: model.collapsed ? getComboBBox([], graph) : comboBBox,
         group: comboGroup,
       });

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1764,6 +1764,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
    * @param children 添加到 Combo 中的元素，包括节点和 combo
    */
   public createCombo(combo: string | ComboConfig, children: string[]): void {
+    const itemController: ItemController = this.get('itemController');
+
     this.set('comboSorted', false);
     // step 1: 创建新的 Combo
     let comboId = '';
@@ -1783,14 +1785,52 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       comboConfig = combo;
     }
 
-    // step2: 更新 children，根据类型添加 comboId 或 parentId
+    // step 2: Pull children out of their parents
+    let comboTrees = this.get('comboTrees');
+    const isChildById = new Set(children);
+    const pulledComboTreesById = new Map();
+
+    if (comboTrees) {
+      comboTrees.forEach(ctree => {
+        traverseTreeUp<ComboTree>(ctree, (treeNode, parentTreeNode, index) => {
+          if (isChildById.has(treeNode.id)) {
+            if (parentTreeNode) {
+              const parentItem = this.findById(parentTreeNode.id) as ICombo;
+              const item = this.findById(treeNode.id) as INode | ICombo;
+
+              // Removing current item from the tree during the traversal is ok because children traversal is done
+              // in an *inverse order* - indices of the next-traversed items are not disturbed by the removal.
+              parentTreeNode.children.splice(index, 1);
+              parentItem.removeChild(item);
+
+              // We have to update the parent node geometry since nodes were removed from them, _while they are still visible_
+              // (combos may be moved inside the new combo and become hidden)
+              itemController.updateCombo(parentItem, parentTreeNode.children);
+            }
+
+            if (treeNode.itemType === 'combo') {
+              pulledComboTreesById.set(treeNode.id, treeNode);
+            }
+          }
+
+          return true;
+        });
+      });
+      comboTrees = (comboTrees || []).filter(ctree => !isChildById.has(ctree.id));
+
+      this.set('comboTrees', comboTrees);
+    }
+
+    // step 3: 更新 children，根据类型添加 comboId 或 parentId
     const trees: ComboTree[] = children.map(elementId => {
       const item = this.findById(elementId);
       const model = item.getModel();
 
       let type = '';
       if (item.getType) type = item.getType();
-      const cItem: ComboTree = {
+
+      // Combos will be just moved around, so their children can be preserved
+      const cItem: ComboTree = pulledComboTreesById.get(elementId) || {
         id: item.getID(),
         itemType: type as 'node' | 'combo',
       };
@@ -1808,23 +1848,25 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     comboConfig.children = trees;
 
-    // step 3: 添加 Combo，addItem 时会将子将元素添加到 Combo 中
+    // step 4: 添加 Combo，addItem 时会将子将元素添加到 Combo 中
     this.addItem('combo', comboConfig, false);
     this.set('comboSorted', false);
 
-    // step4: 更新 comboTrees 结构
-    const comboTrees = this.get('comboTrees');
-    (comboTrees || []).forEach(ctree => {
-      traverseTreeUp<ComboTree>(ctree, child => {
-        if (child.id === comboId) {
-          child.itemType = 'combo';
-          child.children = trees as ComboTree[];
-          return false;
-        }
-        return true;
-      });
-    });
+    // step 5: 更新 comboTrees 结构
     if (comboTrees) {
+      comboTrees.forEach(ctree => {
+        traverseTree<ComboTree>(ctree, (treeNode) => {
+          // Set the children to the newly created combo
+          if (treeNode.id === comboId) {
+            treeNode.itemType = 'combo';
+            treeNode.children = trees as ComboTree[];
+            return false;
+          }
+
+          return true;
+        });
+      });
+
       this.sortCombos();
     }
   }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1787,13 +1787,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     // step 2: Pull children out of their parents
     let comboTrees = this.get('comboTrees');
-    const isChildById = new Set(children);
+    const childrenIdsSet = new Set(children);
     const pulledComboTreesById = new Map();
 
     if (comboTrees) {
       comboTrees.forEach(ctree => {
         traverseTreeUp<ComboTree>(ctree, (treeNode, parentTreeNode, index) => {
-          if (isChildById.has(treeNode.id)) {
+          if (childrenIdsSet.has(treeNode.id)) {
             if (parentTreeNode) {
               const parentItem = this.findById(parentTreeNode.id) as ICombo;
               const item = this.findById(treeNode.id) as INode | ICombo;
@@ -1816,7 +1816,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return true;
         });
       });
-      comboTrees = comboTrees.filter(ctree => !isChildById.has(ctree.id));
+      comboTrees = comboTrees.filter(ctree => !childrenIdsSet.has(ctree.id));
 
       this.set('comboTrees', comboTrees);
     }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1816,7 +1816,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return true;
         });
       });
-      comboTrees = (comboTrees || []).filter(ctree => !isChildById.has(ctree.id));
+      comboTrees = comboTrees.filter(ctree => !isChildById.has(ctree.id));
 
       this.set('comboTrees', comboTrees);
     }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1787,8 +1787,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
 
     // step 2: Pull children out of their parents
     let comboTrees = this.get('comboTrees');
-    const childrenIdsSet = new Set(children);
-    const pulledComboTreesById = new Map();
+    const childrenIdsSet = new Set<string>(children);
+    const pulledComboTreesById = new Map<string, ComboTree>();
 
     if (comboTrees) {
       comboTrees.forEach(ctree => {

--- a/packages/core/tests/unit/state/image-state-spec.ts
+++ b/packages/core/tests/unit/state/image-state-spec.ts
@@ -25,7 +25,7 @@ describe('graph node states', () => {
           position: 'bottom',
           style: {  fill: '#e80a0a', fontSize: 10,}
         },
-      }
+      },
       nodeStateStyles: {
         hover: {
           img: 'https://gw.alipayobjects.com/zos/bmw-prod/5d015065-8505-4e7a-baec-976f81e3c41d.svg',

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-element",
-  "version": "0.7.4-siren.1",
+  "version": "0.7.4-siren.2",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@antv/g-base": "^0.5.1",
-    "@antv/g6-core": "0.7.4-siren.1",
+    "@antv/g6-core": "0.7.4-siren.2",
     "@antv/util": "~2.0.5"
   },
   "devDependencies": {
@@ -87,6 +87,6 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^7.0.3",
     "typescript": "^4.6.3",
-    "@antv/g6": "4.7.4-siren.1"
+    "@antv/g6": "4.7.4-siren.2"
   }
 }

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "4.7.4-siren.1",
+  "version": "4.7.4-siren.2",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -66,7 +66,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-pc": "0.7.4-siren.1"
+    "@antv/g6-pc": "0.7.4-siren.2"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/pc/package.json
+++ b/packages/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-pc",
-  "version": "0.7.4-siren.1",
+  "version": "0.7.4-siren.2",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -75,9 +75,9 @@
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-math": "^0.1.1",
     "@antv/g-svg": "^0.5.1",
-    "@antv/g6-core": "0.7.4-siren.1",
-    "@antv/g6-element": "0.7.4-siren.1",
-    "@antv/g6-plugin": "0.7.4-siren.1",
+    "@antv/g6-core": "0.7.4-siren.2",
+    "@antv/g6-element": "0.7.4-siren.2",
+    "@antv/g6-plugin": "0.7.4-siren.2",
     "@antv/hierarchy": "^0.6.7",
     "@antv/layout": "^0.3.0",
     "@antv/matrix-util": "^3.1.0-beta.3",

--- a/packages/pc/src/global.ts
+++ b/packages/pc/src/global.ts
@@ -7,7 +7,7 @@ const textColor = 'rgb(0, 0, 0)';
 const colorSet = getColorsWithSubjectColor(subjectColor, backColor);
 
 export default {
-  version: '0.7.4-siren.0',
+  version: '0.7.4-siren.2',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-plugin",
-  "version": "0.7.4-siren.1",
+  "version": "0.7.4-siren.2",
   "description": "G6 Plugin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -22,8 +22,8 @@
     "@antv/g-base": "^0.5.1",
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-svg": "^0.5.2",
-    "@antv/g6-core": "0.7.4-siren.1",
-    "@antv/g6-element": "0.7.4-siren.1",
+    "@antv/g6-core": "0.7.4-siren.2",
+    "@antv/g6-element": "0.7.4-siren.2",
     "@antv/matrix-util": "^3.1.0-beta.3",
     "@antv/scale": "^0.3.4",
     "@antv/util": "^2.0.9",
@@ -59,6 +59,6 @@
     "jquery": "^3.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "@antv/g6": "4.7.4-siren.1"
+    "@antv/g6": "4.7.4-siren.2"
   }
 }

--- a/packages/react-node/package.json
+++ b/packages/react-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/g6-react-node",
   "description": "Using React Component to Define Your G6 Graph Node",
-  "version": "1.4.5-siren.4",
+  "version": "1.4.5-siren.5",
   "scripts": {
     "start": "dumi dev",
     "build": "father-build",
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-core": "0.7.4-siren.1",
+    "@antv/g6-core": "0.7.4-siren.2",
     "@antv/g-base": "^0.5.1",
     "@types/yoga-layout": "^1.9.3",
     "react": "^16.12.0",

--- a/packages/site/docs/api/Util.en.md
+++ b/packages/site/docs/api/Util.en.md
@@ -60,7 +60,15 @@ Traverse the tree data depth-first from top (the root) to bottom (the leaves).
 | Name | Type     | Required | Description                                    |
 | ---- | -------- | -------- | ---------------------------------------------- |
 | data | TreeData | true     | The tree data to be traversed                  |
-| fn   | function | true     | The callback function called when visit a node |
+| fn   | function | true     | The callback function called when visit a node. Returning `false` from the callback function will stop traversal. |
+
+Callback parameters
+
+| Name     | Type     | Description                                            |
+| -------- | -------- | ------------------------------------------------------ |
+| node     | T        | Tree node being currently visited                      |
+| parent   | T | null | Parent of the current tree node                        |
+| index    | number   | Index of current tree node among the parent's children |
 
 #### Usage
 
@@ -104,7 +112,15 @@ Traverse the tree data depth-first from bottom (the leaves) to top (the root).
 | Name | Type     | Required | Description                                    |
 | ---- | -------- | -------- | ---------------------------------------------- |
 | data | TreeData | true     | The tree data to be traversed                  |
-| fn   | function | true     | The callback function called when visit a node |
+| fn   | function | true     | The callback function called when visit a node. Returning `false` from the callback function will stop traversal. |
+
+Callback parameters
+
+| Name     | Type     | Description                                            |
+| -------- | -------- | ------------------------------------------------------ |
+| node     | T        | Tree node being currently visited                      |
+| parent   | T | null | Parent of the current tree node                        |
+| index    | number   | Index of current tree node among the parent's children |
 
 #### Usage
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@antv/g6-site",
-  "version": "4.7.4-siren.1",
+  "version": "4.7.4-siren.2",
   "description": "G6 sites deployed on gh-pages",
   "keywords": [
     "antv",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@antv/chart-node-g6": "^0.0.3",
-    "@antv/g6": "4.7.4-siren.1",
+    "@antv/g6": "4.7.4-siren.2",
     "@antv/gatsby-theme-antv": "1.1.15",
     "@antv/util": "^2.0.9",
     "@antv/vis-predict-engine": "^0.1.1",


### PR DESCRIPTION
##### Checklist

This PR fixes the update of the `comboTrees` structure involved in a `createCombo()` call. In particular:
- Combos moved inside the newly create combo were not removed from the `comboTrees`, which means they ended up duplicated (in the original place and under the new combo)
- Combos moved inside the new combo had no children

------

This PR (also) fixes the `animate` property initialization for new combos, which should be inherited from the graph itself rather than just set to `false`.

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->
