### PR TITLE
Remove umd build. Also, separate build from publish.

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -45,9 +45,10 @@ pipeline {
           ]
         ]) {
           sh 'curl -u"${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" https://artifactory.siren.io/artifactory/api/npm/sirensolutions-npm-local/auth/antv > ~/.npmrc'
+          sh 'npm run build:all'
           script {
             ['core', 'element', 'plugin', 'pc', 'g6'].each {
-              sh "cd packages/${it} && npm run build && npm publish --registry=https://artifactory.siren.io/artifactory/api/npm/sirensolutions-npm-local && cd .."
+              sh "cd packages/${it} && npm publish --registry=https://artifactory.siren.io/artifactory/api/npm/sirensolutions-npm-local && cd .."
             }
           }
         }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-core",
-  "version": "0.7.4-siren.2",
+  "version": "0.7.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -64,7 +64,7 @@ const colorSet = {
 };
 
 export default {
-  version: '0.7.4-siren.2',
+  version: '0.7.4-siren.3',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-element",
-  "version": "0.7.4-siren.2",
+  "version": "0.7.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@antv/g-base": "^0.5.1",
-    "@antv/g6-core": "0.7.4-siren.2",
+    "@antv/g6-core": "0.7.4-siren.3",
     "@antv/util": "~2.0.5"
   },
   "devDependencies": {
@@ -87,6 +87,6 @@
     "ts-jest": "^24.1.0",
     "ts-loader": "^7.0.3",
     "typescript": "^4.6.3",
-    "@antv/g6": "4.7.4-siren.2"
+    "@antv/g6": "4.7.4-siren.3"
   }
 }

--- a/packages/g6/package.json
+++ b/packages/g6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6",
-  "version": "4.7.4-siren.2",
+  "version": "4.7.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -35,7 +35,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "start": "father build --watch",
-    "build": "npm run clean && father build && npm run build:umd",
+    "build": "npm run clean && father build",
     "build:umd": "webpack --config webpack.config.js --mode production",
     "ci": "npm run build && npm run coverage",
     "clean": "rimraf es esm lib dist",
@@ -66,7 +66,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-pc": "0.7.4-siren.2"
+    "@antv/g6-pc": "0.7.4-siren.3"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/packages/pc/package.json
+++ b/packages/pc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-pc",
-  "version": "0.7.4-siren.2",
+  "version": "0.7.4-siren.3",
   "description": "A Graph Visualization Framework in JavaScript",
   "keywords": [
     "antv",
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "npm run clean && father build && npm run build:umd",
+    "build": "npm run clean && father build",
     "build:umd": "webpack --config webpack.config.js --mode production",
     "build:umd:profile": "webpack --config webpack.config.js --mode production --profile --json > stats.json",
     "cdn": "antv-bin upload -n @antv/g6",
@@ -75,9 +75,9 @@
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-math": "^0.1.1",
     "@antv/g-svg": "^0.5.1",
-    "@antv/g6-core": "0.7.4-siren.2",
-    "@antv/g6-element": "0.7.4-siren.2",
-    "@antv/g6-plugin": "0.7.4-siren.2",
+    "@antv/g6-core": "0.7.4-siren.3",
+    "@antv/g6-element": "0.7.4-siren.3",
+    "@antv/g6-plugin": "0.7.4-siren.3",
     "@antv/hierarchy": "^0.6.7",
     "@antv/layout": "^0.3.0",
     "@antv/matrix-util": "^3.1.0-beta.3",

--- a/packages/pc/src/global.ts
+++ b/packages/pc/src/global.ts
@@ -7,7 +7,7 @@ const textColor = 'rgb(0, 0, 0)';
 const colorSet = getColorsWithSubjectColor(subjectColor, backColor);
 
 export default {
-  version: '0.7.4-siren.2',
+  version: '0.7.4-siren.3',
   rootContainerClassName: 'root-container',
   nodeContainerClassName: 'node-container',
   edgeContainerClassName: 'edge-container',

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/g6-plugin",
-  "version": "0.7.4-siren.2",
+  "version": "0.7.4-siren.3",
   "description": "G6 Plugin",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -22,8 +22,8 @@
     "@antv/g-base": "^0.5.1",
     "@antv/g-canvas": "^0.5.2",
     "@antv/g-svg": "^0.5.2",
-    "@antv/g6-core": "0.7.4-siren.2",
-    "@antv/g6-element": "0.7.4-siren.2",
+    "@antv/g6-core": "0.7.4-siren.3",
+    "@antv/g6-element": "0.7.4-siren.3",
     "@antv/matrix-util": "^3.1.0-beta.3",
     "@antv/scale": "^0.3.4",
     "@antv/util": "^2.0.9",
@@ -59,6 +59,6 @@
     "jquery": "^3.5.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
-    "@antv/g6": "4.7.4-siren.2"
+    "@antv/g6": "4.7.4-siren.3"
   }
 }

--- a/packages/react-node/package.json
+++ b/packages/react-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antv/g6-react-node",
   "description": "Using React Component to Define Your G6 Graph Node",
-  "version": "1.4.5-siren.5",
+  "version": "1.4.5-siren.6",
   "scripts": {
     "start": "dumi dev",
     "build": "father-build",
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@antv/g6-core": "0.7.4-siren.2",
+    "@antv/g6-core": "0.7.4-siren.3",
     "@antv/g-base": "^0.5.1",
     "@types/yoga-layout": "^1.9.3",
     "react": "^16.12.0",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@antv/g6-site",
-  "version": "4.7.4-siren.2",
+  "version": "4.7.4-siren.3",
   "description": "G6 sites deployed on gh-pages",
   "keywords": [
     "antv",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@antv/chart-node-g6": "^0.0.3",
-    "@antv/g6": "4.7.4-siren.2",
+    "@antv/g6": "4.7.4-siren.3",
     "@antv/gatsby-theme-antv": "1.1.15",
     "@antv/util": "^2.0.9",
     "@antv/vis-predict-engine": "^0.1.1",


### PR DESCRIPTION
##### Description of change

This PR removes the UMD build since we just use the CJS one. The UMD one failed to build (probably due to not enough RAM on the runner).

Additionally, the building step is now separate from the publish step in the Jenkins pipeline, so a failing build in one of the sub-packages won't result in half-published monorepo artifacts.