### PR TITLE
[INVE 19878] Clear animations before zoom

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -747,8 +747,10 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         callback: () => this.emit('viewportchange', { action: 'zoom', matrix: group.getMatrix() })
       });
 
-      // Clear animations to prevent zoom-in and zoom-out animations to be triggered together
-      group.set('animations', []);
+      if (animate) {
+        // Clear animations to prevent zoom-in and zoom-out animations to be triggered together
+        group.set('animations', []);
+      }
       
       group.animate((ratio: number) => {
         if (ratio === 1) {

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -747,6 +747,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         callback: () => this.emit('viewportchange', { action: 'zoom', matrix: group.getMatrix() })
       });
 
+      // Clear animations to prevent zoom-in and zoom-out animations to be triggered together
+      group.set('animations', []);
+      
       group.animate((ratio: number) => {
         if (ratio === 1) {
           // Reuse the first transformation


### PR DESCRIPTION
[INVE 19878](https://sirensolutions.atlassian.net/browse/INVE-19878)

##### Description of change

Clear animations before zoom.

To test it simply add 
```javascript
group.set('animations', []);
```
in `.../kibi-internal/node_modules/@antv/g6-core/lib/graph/graph.js` line number 790

