### PR TITLE
fix: Unselected combos should now be added to undo/redo stack when moved

### DIFF
--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -369,9 +369,8 @@ export default {
     const graph: IGraph = this.graph;
 
     if (graph.get('enabledStack')) {
-      const combos = graph.findAllByState('combo', this.selectedState);
-      if (combos.length) {
-        pushComboToStack(graph, combos);
+      if (this.targets.length) {
+        pushComboToStack(graph, this.targets);
       }
     }
 

--- a/packages/pc/src/behavior/drag-combo.ts
+++ b/packages/pc/src/behavior/drag-combo.ts
@@ -33,6 +33,7 @@ const traverseCombo = (data, fn: (param: any) => boolean) => {
   }
 };
 
+// *Siren* Added for single combo action (undo/redo)
 /**
  * Pushes the combo and its children to
  * stack, if redo is not empty it's cleared.
@@ -183,6 +184,7 @@ export default {
       return true;
     });
 
+    // *Siren* Added for single combo action (undo/redo)
     if (graph.get('enabledStack') && combos.length) {
       pushComboToStack(graph, combos);
     }
@@ -368,6 +370,7 @@ export default {
     const parentCombo = this.getParentCombo(item.getModel().parentId);
     const graph: IGraph = this.graph;
 
+    // *Siren* Added for single combo action (undo/redo)
     if (graph.get('enabledStack')) {
       if (this.targets.length) {
         pushComboToStack(graph, this.targets);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Only selected combos were being added to the stack when being dragged.
