### PR TITLE
fix: Fixed issue of nested child combo being rendered under parent, …

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1901,6 +1901,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         after: newChildrenParent
       });
     }
+
+    // Fixes issue of nested child combos not being interactive (under parent on graph).
+    const comboItem = this.findById(comboId) as ICombo;
+
+    if (!comboItem.getModel().parentId && comboItem.getChildren().combos.length) {
+      this.updateComboTree(comboItem, undefined, false);
+    }
   }
 
   /**


### PR DESCRIPTION
…preventing interation with it

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Combo tree will be updated if the combo does not have a parent and contains nested combos.

before:

https://user-images.githubusercontent.com/7975925/220897934-41e7eb77-e51b-464d-a2e3-8e01812286ed.mp4

after:

https://user-images.githubusercontent.com/7975925/220898002-535b52e2-74d5-4416-94c1-ea4a70a26141.mp4


