### PR TITLE
[INVE-21143] Update combo visibility state on changeData

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1667,11 +1667,14 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     }
 
     this.diffItems('node', items, (data as GraphData).nodes!);
-
+    const invisibleCombos = new Set();
     each(itemMap, (item: INode & IEdge & ICombo, id: number) => {
       itemMap[id].getModel().depth = 0;
       if (item.getType && item.getType() === 'edge') return;
       if (item.getType && item.getType() === 'combo') {
+        if (!item.isVisible()) {
+          invisibleCombos.add(item.getID());
+        }
         delete itemMap[id];
         item.destroy();
       } else if (items.nodes.indexOf(item) < 0) {
@@ -1697,6 +1700,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         this.sortCombos();
       }
     }
+    
+    // set visibility state of combos as before
+    self.getCombos().forEach(combo => {
+      if (invisibleCombos.has(combo.getID())) {
+        combo.hide();
+      }
+    })
 
     this.diffItems('edge', items, (data as GraphData).edges!);
     each(itemMap, (item: INode & IEdge & ICombo, id: number) => {


### PR DESCRIPTION

[INVE-21143] 

##### Description of change

Previously when `changeData(newGraphModel)` was called, the visibility state of nodes were preserved, but not for the combos. This change updates the visibility states on the recreated combos. 

[INVE-21143]: https://sirensolutions.atlassian.net/browse/INVE-21143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ