### PR TITLE
[INVE-26256] - Add logic to have custom label on vedge

### DIFF
--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2849,10 +2849,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 收起指定的 combo
    * @param {string | ICombo} combo combo ID 或 combo item
-   * @param {object} [opts] - Optional parameter for the collapse operation.
-   * @param {boolean} [opts.inheritLabel=true] - If true, the virtual edge inherits the label from connected edges
+   * @param {boolean} [stack] Default is true. If true, the collase operation is recorded in the stack.
+   * @param {object} [opts] Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=false] Default is false. If true, the virtual edge inherits the label from connected edges
    *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
-   * @param {boolean} [opts.showCount=true] - If true, displays the count of edges merged to form a virtual edge.
+   * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
   public collapseCombo(combo: string | ICombo, stack: boolean = true, opts: {
     inheritLabel: boolean,
@@ -2996,10 +2997,11 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 展开指定的 combo
    * @param {string | ICombo} combo combo ID 或 combo item
-   * @param {object} [opts] - Optional parameter for the collapse operation.
-   * @param {boolean} [opts.inheritLabel=true] - If true, the virtual edge inherits the label from connected edges
+   * @param {boolean} [stack] Default is true. If true, the expand operation is recorded in the stack.
+   * @param {object} [opts] Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=false] Default is false. If true, the virtual edge inherits the label from connected edges
    *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
-   * @param {boolean} [opts.showCount=true] - If true, displays the count of edges merged to form a virtual edge.
+   * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
   public expandCombo(combo: string | ICombo, stack: boolean = true, opts: {
     inheritLabel: boolean,

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2755,13 +2755,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     return hasStart && hasEnd ? 'both' : hasStart ? 'start' : hasEnd ? 'end' : 'none';
   }
 
-  private processEdgeLabels(edgeInfo) {
-    const totalCount = edgeInfo.count;
-    const { allSameLabel, firstLabel } = edgeInfo;
+  private processEdgeLabels(edgeInfo, opts) {
+    const { showCount, inheritLabel } = opts;
+    const { count, allSameLabel, firstLabel } = edgeInfo;
 
-    edgeInfo.style.label.value = allSameLabel && firstLabel !== ''
-      ? `${firstLabel} (${totalCount})`
-      : `(${totalCount})`;
+    edgeInfo.style.label.value = (inheritLabel && allSameLabel && firstLabel !== '')
+      ? `${firstLabel}${showCount ? ` (${count})` : ''}`
+      : (showCount ? `(${count})` : '');
   }
 
   private setArrowDirections(edgeInfo) {
@@ -2849,12 +2849,16 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 收起指定的 combo
    * @param {string | ICombo} combo combo ID 或 combo item
+   * @param {object} [opts] - Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=true] - If true, the virtual edge inherits the label from connected edges
+   *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
+   * @param {boolean} [opts.showCount=true] - If true, displays the count of edges merged to form a virtual edge.
    */
   public collapseCombo(combo: string | ICombo, stack: boolean = true, opts: {
-    inheritLabelWithDir: boolean,
+    inheritLabel: boolean,
     showCount: boolean
   } = {
-    inheritLabelWithDir: true,
+    inheritLabel: true,
     showCount: true
   }): void {
     if (this.destroyed) return;
@@ -2955,7 +2959,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         const key = `${vEdgeInfo.source}-${vEdgeInfo.target}`;
         const inverseKey = `${vEdgeInfo.target}-${vEdgeInfo.source}`;
 
-        if (opts.inheritLabelWithDir && opts.showCount) {
+        if (opts.inheritLabel || opts.showCount) {
           this.updateVEdgeMap(addedVEdgeMap, key, inverseKey, vEdgeInfo,
             edgeLabel,edgeDirection, size, edgeModel
           );
@@ -2975,9 +2979,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       }
     });
 
-    if (opts.inheritLabelWithDir && opts.showCount) {
+    if (opts.inheritLabel || opts.showCount) {
       Object.values(addedVEdgeMap).forEach(edgeInfo => {
-        this.processEdgeLabels(edgeInfo);
+        this.processEdgeLabels(edgeInfo, opts);
         this.setArrowDirections(edgeInfo);
       });
     }
@@ -2993,12 +2997,16 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
   /**
    * 展开指定的 combo
    * @param {string | ICombo} combo combo ID 或 combo item
+   * @param {object} [opts] - Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=true] - If true, the virtual edge inherits the label from connected edges
+   *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
+   * @param {boolean} [opts.showCount=true] - If true, displays the count of edges merged to form a virtual edge.
    */
   public expandCombo(combo: string | ICombo, stack: boolean = true, opts: {
-    inheritLabelWithDir: boolean,
+    inheritLabel: boolean,
     showCount: boolean
   } = {
-    inheritLabelWithDir: true,
+    inheritLabel: true,
     showCount: true
   }): void {
     if (isString(combo)) {
@@ -3125,7 +3133,7 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           const vedgeId = `${vEdgeInfo.source}-${vEdgeInfo.target}`;
           const inverseVedgeId = `${vEdgeInfo.target}-${vEdgeInfo.source}`;
 
-          if (opts.inheritLabelWithDir && opts.showCount) {
+          if (opts.inheritLabel || opts.showCount) {
             this.updateVEdgeMap(addedVEdgeMap, vedgeId, inverseVedgeId, vEdgeInfo,
               edgeLabel,edgeDirection, size, edgeModel
             );
@@ -3143,9 +3151,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
       }
     });
 
-    if (opts.inheritLabelWithDir && opts.showCount) {
+    if (opts.inheritLabel || opts.showCount) {
       Object.values(addedVEdgeMap).forEach(edgeInfo => {
-        this.processEdgeLabels(edgeInfo);
+        this.processEdgeLabels(edgeInfo, opts);
         this.setArrowDirections(edgeInfo);
       });
     }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -3165,7 +3165,13 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     this.emit('aftercollapseexpandcombo', { action: 'expand', item: combo });
   }
 
-  public collapseExpandCombo(combo: string | ICombo, stack: boolean = true) {
+  public collapseExpandCombo(combo: string | ICombo, stack: boolean = true, opts: {
+    inheritLabel: boolean,
+    showCount: boolean
+  } = {
+    inheritLabel: true,
+    showCount: true
+  }) {
     if (isString(combo)) {
       combo = this.findById(combo) as ICombo;
     }
@@ -3187,9 +3193,9 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     const collapsed = comboModel.collapsed;
     // 该群组已经处于收起状态，需要展开
     if (collapsed) {
-      this.expandCombo(combo, stack);
+      this.expandCombo(combo, stack, opts);
     } else {
-      this.collapseCombo(combo, stack);
+      this.collapseCombo(combo, stack, opts);
     }
     this.updateCombo(combo);
   }

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -3169,8 +3169,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     inheritLabel: boolean,
     showCount: boolean
   } = {
-    inheritLabel: true,
-    showCount: true
+    inheritLabel: false,
+    showCount: false
   }) {
     if (isString(combo)) {
       combo = this.findById(combo) as ICombo;

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -2858,8 +2858,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     inheritLabel: boolean,
     showCount: boolean
   } = {
-    inheritLabel: true,
-    showCount: true
+    inheritLabel: false,
+    showCount: false
   }): void {
     if (this.destroyed) return;
     if (isString(combo)) {
@@ -2930,10 +2930,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           return;
         }
         let otherEndModel = otherEnd.getModel();
-        const edgeModel = edge.getModel();
-        const edgeLabel = edgeModel.label || edgeModel.style?.label?.value || '';
-        const { style } = edgeModel;
-        const edgeDirection = this.getEdgeDirection(style);
 
         while (!otherEnd.isVisible()) {
           const { parentId: otherEndPId, comboId: otherEndCId } = otherEndModel;
@@ -2960,11 +2956,14 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
         const inverseKey = `${vEdgeInfo.target}-${vEdgeInfo.source}`;
 
         if (opts.inheritLabel || opts.showCount) {
+          const edgeModel = edge.getModel();
+          const edgeLabel = edgeModel.label || edgeModel.style?.label?.value || '';
+          const { style } = edgeModel;
+          const edgeDirection = this.getEdgeDirection(style);
           this.updateVEdgeMap(addedVEdgeMap, key, inverseKey, vEdgeInfo,
             edgeLabel,edgeDirection, size, edgeModel
           );
-        }
-        else {
+        } else {
           if (addedVEdgeMap[key]) {
             addedVEdgeMap[key].size += size;
             return;
@@ -3006,8 +3005,8 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
     inheritLabel: boolean,
     showCount: boolean
   } = {
-    inheritLabel: true,
-    showCount: true
+    inheritLabel: false,
+    showCount: false
   }): void {
     if (isString(combo)) {
       combo = this.findById(combo) as ICombo;
@@ -3083,10 +3082,6 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           this.removeItem(edge, false);
           return;
         }
-        const edgeModel = edge.getModel();
-        const edgeLabel = edgeModel.label || edgeModel.style?.label?.value || '';
-        const { style } = edgeModel;
-        const edgeDirection = this.getEdgeDirection(style);
 
         let otherEndModel = otherEnd.getModel();
         // find the nearest visible ancestor
@@ -3134,11 +3129,14 @@ export default abstract class AbstractGraph extends EventEmitter implements IAbs
           const inverseVedgeId = `${vEdgeInfo.target}-${vEdgeInfo.source}`;
 
           if (opts.inheritLabel || opts.showCount) {
+            const edgeModel = edge.getModel();
+            const edgeLabel = edgeModel.label || edgeModel.style?.label?.value || '';
+            const { style } = edgeModel;
+            const edgeDirection = this.getEdgeDirection(style);
             this.updateVEdgeMap(addedVEdgeMap, vedgeId, inverseVedgeId, vEdgeInfo,
               edgeLabel,edgeDirection, size, edgeModel
             );
-          }
-          else {
+          } else {
             // update the width of the virtual edges, which is the sum of merged actual edges
             // be attention that the actual edges with same endpoints but different directions will be represented by two different virtual edges
             if (addedVEdgeMap[vedgeId]) {

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -533,7 +533,6 @@ export interface IAbstractGraph extends EventEmitter {
    *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
    * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
-  // collapseCombo: (combo: string | ICombo, stack?: boolean) => void;
   collapseCombo: (combo: string | ICombo, stack?: boolean, opts?: {inheritLabel: boolean, showCount: boolean}) => void;
 
   /**
@@ -545,14 +544,13 @@ export interface IAbstractGraph extends EventEmitter {
    *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
    * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
-  // expandCombo: (combo: string | ICombo, stack?: boolean) => void;
   expandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabel: boolean, showCount: boolean }) => void;
 
   /**
    * 展开或收缩指定的 Combo
    * @param comboId combo ID 或 combo 实例
    */
-  collapseExpandCombo: (combo: string | ICombo, stack?: boolean) => void;
+  collapseExpandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabel: boolean, showCount: boolean }) => void;
 
   /**
    * 根据节点的 bbox 更新所有 combos 的绘制，包括 combos 的位置和范围

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -529,14 +529,14 @@ export interface IAbstractGraph extends EventEmitter {
    * @param comboId combo ID 或 combo 实例
    */
   // collapseCombo: (combo: string | ICombo, stack?: boolean) => void;
-  collapseCombo: (combo: string | ICombo, stack?: boolean, opts?: {inheritLabelWithDir: boolean, showCount: boolean}) => void;
+  collapseCombo: (combo: string | ICombo, stack?: boolean, opts?: {inheritLabel: boolean, showCount: boolean}) => void;
 
   /**
    * 展开指定的 Combo
    * @param combo combo ID 或 combo 实例
    */
   // expandCombo: (combo: string | ICombo, stack?: boolean) => void;
-  expandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabelWithDir: boolean, showCount: boolean }) => void;
+  expandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabel: boolean, showCount: boolean }) => void;
 
   /**
    * 展开或收缩指定的 Combo

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -527,6 +527,11 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * 收起指定的 Combo
    * @param comboId combo ID 或 combo 实例
+   * @param {boolean} [stack] Default is true. If true, the collase operation is recorded in the stack.
+   * @param {object} [opts] Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=false] Default is false. If true, the virtual edge inherits the label from connected edges
+   *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
+   * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
   // collapseCombo: (combo: string | ICombo, stack?: boolean) => void;
   collapseCombo: (combo: string | ICombo, stack?: boolean, opts?: {inheritLabel: boolean, showCount: boolean}) => void;
@@ -534,6 +539,11 @@ export interface IAbstractGraph extends EventEmitter {
   /**
    * 展开指定的 Combo
    * @param combo combo ID 或 combo 实例
+   * @param {boolean} [stack] Default is true. If true, the expand operation is recorded in the stack.
+   * @param {object} [opts] Optional parameter for the collapse operation.
+   * @param {boolean} [opts.inheritLabel=false] Default is false. If true, the virtual edge inherits the label from connected edges
+   *   only if all connected edges have identical labels. Otherwise, the vedge will have a blank label.
+   * @param {boolean} [opts.showCount=false] Default is false. If true, displays the count of edges merged to form a virtual edge.
    */
   // expandCombo: (combo: string | ICombo, stack?: boolean) => void;
   expandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabel: boolean, showCount: boolean }) => void;

--- a/packages/core/src/interface/graph.ts
+++ b/packages/core/src/interface/graph.ts
@@ -528,13 +528,15 @@ export interface IAbstractGraph extends EventEmitter {
    * 收起指定的 Combo
    * @param comboId combo ID 或 combo 实例
    */
-  collapseCombo: (combo: string | ICombo, stack?: boolean) => void;
+  // collapseCombo: (combo: string | ICombo, stack?: boolean) => void;
+  collapseCombo: (combo: string | ICombo, stack?: boolean, opts?: {inheritLabelWithDir: boolean, showCount: boolean}) => void;
 
   /**
    * 展开指定的 Combo
    * @param combo combo ID 或 combo 实例
    */
-  expandCombo: (combo: string | ICombo, stack?: boolean) => void;
+  // expandCombo: (combo: string | ICombo, stack?: boolean) => void;
+  expandCombo: (combo: string | ICombo, stack?: boolean, opts?: { inheritLabelWithDir: boolean, showCount: boolean }) => void;
 
   /**
    * 展开或收缩指定的 Combo

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -1771,7 +1771,7 @@ describe('states', () => {
   });
 });
 
-describe.only('Custom label and direction on VEdge', () => {
+describe('Custom label and direction on VEdge', () => {
   let graph: Graph;
   let combo: ICombo;
 

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -1770,3 +1770,125 @@ describe('states', () => {
     expect(savedGraph.combos[1].states).toEqual({});
   });
 });
+
+describe.only('Custom label and direction on VEdge', () => {
+  let graph: Graph;
+  let combo: ICombo;
+
+  beforeEach(() => {
+    graph = new Graph({
+      container: div,
+      height: 500,
+      width: 500,
+    });
+
+    const comboId = 'testCombo';
+    graph.addItem('combo', { id: comboId });
+    combo = graph.findById(comboId) as ICombo;
+    graph.addItem('node', { id: 'node1', comboId, x: 50, y: 50 });
+    graph.addItem('node', { id: 'node2', comboId, x: 150, y: 150 });
+    graph.addItem('node', { id: 'externalNode', x: 250, y: 50 });
+  });
+
+  afterEach(() => {
+    if (!graph.destroyed) graph.destroy();
+  });
+
+  it('should display combined label with count and direction for edges having identical label and direction', () => {
+    graph.addItem('edge', {
+      source: 'node1',
+      target: 'externalNode',
+      label: 'A',
+      style: { keyshape: { startArrow: true }}
+    });
+    graph.addItem('edge', {
+      source: 'node2',
+      target: 'externalNode',
+      label: 'A',
+      style: { keyshape: { startArrow: true }}
+    });
+
+    graph.collapseCombo(combo);
+
+    const vEdges = graph.get('vedges');
+    expect(vEdges.length).toBe(1);
+    const vEdge = vEdges[0].getModel();
+
+    expect(vEdge.style.label.value).toBe('A (2)');
+
+    expect(vEdge.startArrow).toBe(true);
+    expect(vEdge.endArrow).toBeUndefined;
+  });
+
+  it('should display only count and direction on VEdge when combining edges having mixed labels and identical direction', () => {
+    graph.addItem('edge', {
+      source: 'node1',
+      target: 'externalNode',
+      label: 'A',
+      style: { keyshape: { endArrow: true }}
+    });
+    graph.addItem('edge', {
+      source: 'node2',
+      target: 'externalNode',
+      label: 'B',
+      style: { keyshape: { endArrow: true }}
+    });
+
+    graph.collapseCombo(combo);
+
+    const vEdges = graph.get('vedges');
+    expect(vEdges.length).toBe(1);
+    const vEdge = vEdges[0].getModel();
+    expect(vEdge.style.label.value).toBe('(2)');
+    expect(vEdge.endArrow).toBe(true);
+    expect(vEdge.startArrow).toBeUndefined;
+  });
+
+  it('should display combined label with count and no direction for edges having identical label but mix in direction', () => {
+    graph.addItem('edge', {
+      source: 'node1',
+      target: 'externalNode',
+      label: 'A',
+      style: { keyshape: { endArrow: true }}
+    });
+    graph.addItem('edge', {
+      source: 'externalNode',
+      target: 'node2',
+      label: 'A',
+      style: { keyshape: { startArrow: true }}
+    });
+
+    graph.collapseCombo(combo);
+
+    const vEdges = graph.get('vedges');
+    expect(vEdges.length).toBe(1);
+    const vEdge = vEdges[0].getModel();
+    expect(vEdge.style.label.value).toBe('A (2)');
+    expect(vEdge.startArrow).toBeUndefined;
+    expect(vEdge.endArrow).toBeUndefined;
+  });
+
+  it('should display only count and no direction for edges having mix label and mix direction', () => {
+    graph.addItem('edge', {
+      source: 'node1',
+      target: 'externalNode',
+      label: 'A',
+    style: { keyshape: { endArrow: true }}
+    });
+    graph.addItem('edge', {
+      source: 'externalNode',
+      target: 'node2',
+      label: 'B',
+      style: { keyshape: { startArrow: true }}
+    });
+
+    graph.collapseCombo(combo);
+
+    const vEdges = graph.get('vedges');
+    expect(vEdges.length).toBe(1);
+    const vEdge = vEdges[0].getModel();
+    expect(vEdge.style.label.value).toBe('(2)');
+    expect(vEdge.startArrow).toBeUndefined;
+    expect(vEdge.endArrow).toBeUndefined;
+  });
+});

--- a/packages/core/tests/unit/graph/graph-spec.ts
+++ b/packages/core/tests/unit/graph/graph-spec.ts
@@ -1808,7 +1808,7 @@ describe('Custom label and direction on VEdge', () => {
       style: { keyshape: { startArrow: true }}
     });
 
-    graph.collapseCombo(combo);
+    graph.collapseCombo(combo, undefined, {inheritLabel:true, showCount:true},);
 
     const vEdges = graph.get('vedges');
     expect(vEdges.length).toBe(1);
@@ -1834,7 +1834,7 @@ describe('Custom label and direction on VEdge', () => {
       style: { keyshape: { endArrow: true }}
     });
 
-    graph.collapseCombo(combo);
+    graph.collapseCombo(combo, undefined, {inheritLabel:true, showCount:true},);
 
     const vEdges = graph.get('vedges');
     expect(vEdges.length).toBe(1);
@@ -1858,7 +1858,7 @@ describe('Custom label and direction on VEdge', () => {
       style: { keyshape: { startArrow: true }}
     });
 
-    graph.collapseCombo(combo);
+    graph.collapseCombo(combo, undefined, {inheritLabel:true, showCount:true},);
 
     const vEdges = graph.get('vedges');
     expect(vEdges.length).toBe(1);
@@ -1882,7 +1882,7 @@ describe('Custom label and direction on VEdge', () => {
       style: { keyshape: { startArrow: true }}
     });
 
-    graph.collapseCombo(combo);
+    graph.collapseCombo(combo, undefined, {inheritLabel:true, showCount:true},);
 
     const vEdges = graph.get('vedges');
     expect(vEdges.length).toBe(1);

--- a/packages/site/docs/api/graphFunc/combo.en.md
+++ b/packages/site/docs/api/graphFunc/combo.en.md
@@ -99,6 +99,8 @@ Collapse a Combo.
 | Name  | Type            | Required | Description                                           |
 | ----- | --------------- | -------- | ----------------------------------------------------- |
 | combo | string / ICombo | true     | The ID of the combo or the combo item to be collapsed |
+| stack | boolean         | false    | Whether to push this operation in the undo & redo stack.       |
+| opts  | object          | false    | Customize VEdge: `{ inheritLabel: boolean, showCount: boolean }`. If `inheritLabel` is `true` and all edges forming a VEdge have identical labels/directions, the same label/direction is inherited; otherwise, a blank label and no direction appear. If `showCount` is `true`, displays the count of edges merged into the VEdge as a label. |
 
 **Usage**
 
@@ -115,6 +117,8 @@ Expand a Combo.
 | Name  | Type            | Required | Description                                          |
 | ----- | --------------- | -------- | ---------------------------------------------------- |
 | combo | string / ICombo | true     | The ID of the combo or the combo item to be expanded |
+| stack | boolean         | false    | Whether to push this operation in the undo & redo stack.       |
+| opts  | object          | false    | Customize VEdge: `{ inheritLabel: boolean, showCount: boolean }`. If `inheritLabel` is `true` and all edges forming a VEdge have identical labels/directions, the same label/direction is inherited; otherwise, a blank label and no direction appear. If `showCount` is `true`, displays the count of edges merged into the VEdge as a label. |
 
 **Usage**
 
@@ -131,6 +135,8 @@ Expand the `combo` if it is collapsed. Collapse the `combo` if it is expanded.
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
 | combo | string / ICombo | true | The ID of the combo or the combo item to be collapsed or expanded |
+| stack | boolean         | false    | Whether to push this operation in the undo & redo stack.       |
+| opts  | object          | false    | Customize VEdge: `{ inheritLabel: boolean, showCount: boolean }`. If `inheritLabel` is `true` and all edges forming a VEdge have identical labels/directions, the same label/direction is inherited; otherwise, a blank label and no direction appear. If `showCount` is `true`, displays the count of edges merged into the VEdge as a label. |
 
 **Usage**
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g6/blob/master/CONTRIBUTING.md
-->

##### Checklist
Ticket - [https://sirensolutions.atlassian.net/browse/INVE-26256](https://sirensolutions.atlassian.net/browse/INVE-26256)
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
In this PR,
We introduces a functionality to compute a custom label and direction when we group nodes with edges having identical labels and directions.

Rules followed :
1. Identical Labels and Directions
   - Resultant `VEdge` gets `<label> (count)` (e.g., `<some-label> (2)`) and retains the unanimous direction.

2. Identical Labels, Different Directions
   - Resultant `VEdge` gets `<label> (count)` (e.g., `<some-label> (2)`) but no direction.

3. Different Labels and Directions
   - Resultant `VEdge` has a blank label and no direction (default).


### How to Test

1. Clone the G6 repository locally.
2. Check out the branch: `INVE-26256`.
3. Set up and connect `kibi-internal` with `G6` by following the [documentation](https://sirensolutions.atlassian.net/wiki/spaces/EN/pages/3066396692/G6+Graph+Development+notes#G6-local-development-setup). This ensures `kibi-internal` uses the local G6 package with the PR changes.
4. Test the scenarios shown in the attached video.

### Videos

[Screencast from 31-03-25 13:22:20.webm](https://github.com/user-attachments/assets/90e605c1-524a-4b62-b004-53ae23c663ab)

[Screencast from 31-03-25 13:20:18.webm](https://github.com/user-attachments/assets/20151ef0-5743-4e2f-abbc-7a5419cfc39e)

<!-- Provide a description of the change below this comment. -->
